### PR TITLE
cob3218/api-endpoints -- Remaining GET Endpoints and POST Endpoints for Fact, Joke, Recipe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "daycipe.io",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "daycipe.io",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/server/db/conn.js
+++ b/server/db/conn.js
@@ -8,7 +8,7 @@ export const pool = new Pool({
   user: "postgres",         // Your PostgreSQL username
   host: "localhost",        // Your PostgreSQL host
   database: "daycipe",      // Your PostgreSQL database
-  password: "password",     // Your PostgreSQL password
+  password: "postgres",     // Your PostgreSQL password
   port: 5432                // Default PostgreSQL port
 });
 

--- a/server/db/queries/facts.js
+++ b/server/db/queries/facts.js
@@ -1,6 +1,5 @@
 import { pool } from "../conn.js";
 
-// Get all facts (example)
 export const getFacts = async () => {
     const result = await pool.query("SELECT * FROM facts");
     return result.rows;

--- a/server/db/queries/facts.js
+++ b/server/db/queries/facts.js
@@ -9,3 +9,16 @@ export const getCurrentFact = async () => {
     const result = await pool.query("SELECT * FROM facts WHERE facts.date=CURRENT_DATE LIMIT 1");
     return result.rows[0];
 }
+
+export const createFact = async (factData) => {
+    const query = `INSERT INTO facts (date, content, source, category) VALUES ($1, $2, $3, $4) RETURNING id`;
+    const values = [
+        factData.date,
+        factData.content,
+        factData.source,
+        factData.category
+    ];
+    
+    const result = await pool.query(query, values);
+    return result.rows[0].id;
+}

--- a/server/db/queries/jokes.js
+++ b/server/db/queries/jokes.js
@@ -9,3 +9,15 @@ export const getCurrentJokes = async () => {
     const result = await pool.query("SELECT * FROM jokes WHERE jokes.date=CURRENT_DATE ORDER BY score LIMIT 3");
     return result.rows[0];
 }
+
+export const createJoke = async (jokeData) => {
+    const query = `INSERT INTO jokes (date, content, source) VALUES ($1, $2, $3) RETURNING id`;
+    const values = [
+        jokeData.date,
+        jokeData.content,
+        jokeData.source
+    ];
+    
+    const result = await pool.query(query, values);
+    return result.rows[0].id;
+}

--- a/server/db/queries/jokes.js
+++ b/server/db/queries/jokes.js
@@ -11,11 +11,10 @@ export const getCurrentJokes = async () => {
 }
 
 export const createJoke = async (jokeData) => {
-    const query = `INSERT INTO jokes (date, content, source) VALUES ($1, $2, $3) RETURNING id`;
+    const query = `INSERT INTO jokes (date, content) VALUES ($1, $2) RETURNING id`;
     const values = [
         jokeData.date,
-        jokeData.content,
-        jokeData.source
+        jokeData.content
     ];
     
     const result = await pool.query(query, values);

--- a/server/db/queries/jokes.js
+++ b/server/db/queries/jokes.js
@@ -1,1 +1,11 @@
-import conn from "../conn";
+import { pool } from "../conn.js";
+
+export const getJokes = async () => {
+    const result = await pool.query("SELECT * FROM jokes");
+    return result.rows;
+};
+
+export const getCurrentJokes = async () => {
+    const result = await pool.query("SELECT * FROM jokes WHERE jokes.date=CURRENT_DATE ORDER BY score LIMIT 3");
+    return result.rows[0];
+}

--- a/server/db/queries/recipes.js
+++ b/server/db/queries/recipes.js
@@ -1,0 +1,11 @@
+import { pool } from "../conn.js";
+
+export const getRecipes = async () => {
+    const result = await pool.query("SELECT * FROM recipes");
+    return result.rows;
+};
+
+export const getCurrentRecipe = async () => {
+    const result = await pool.query("SELECT * FROM recipes WHERE recipes.date=CURRENT_DATE LIMIT 3");
+    return result.rows[0];
+}

--- a/server/db/queries/recipes.js
+++ b/server/db/queries/recipes.js
@@ -9,3 +9,15 @@ export const getCurrentRecipe = async () => {
     const result = await pool.query("SELECT * FROM recipes WHERE recipes.date=CURRENT_DATE LIMIT 3");
     return result.rows[0];
 }
+
+export const createRecipe = async (recipeData) => {
+    const query = `INSERT INTO recipes (date, content, category) VALUES ($1, $2, $3) RETURNING id`;
+    const values = [
+        recipeData.date,
+        recipeData.content,
+        recipeData.category
+    ];
+    
+    const result = await pool.query(query, values);
+    return result.rows[0].id;
+}

--- a/server/db/queries/recipies.js
+++ b/server/db/queries/recipies.js
@@ -1,1 +1,0 @@
-import conn from "../conn";

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -20,7 +20,7 @@ CREATE TABLE facts (
 );
 
 -- Table for recipes
-CREATE TYPE recipe_category AS ENUM ('veganism', 'vegetarianism', 'lactose_intolerance', 'gluten_intolerance', 'kosher');
+CREATE TYPE recipe_category AS ENUM ('default', 'veganism', 'vegetarianism', 'lactose_intolerance', 'gluten_intolerance', 'kosher');
 
 CREATE TABLE recipes (
     id SERIAL PRIMARY KEY,

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -9,7 +9,7 @@ DROP TYPE IF EXISTS fact_category;
 -- Table for facts
 CREATE TYPE fact_category AS ENUM ('math', 'physics', 'bio', 'compsci', 'chem');
 
-CREATE TABLE  facts (
+CREATE TABLE facts (
     id SERIAL PRIMARY KEY,
     date DATE NOT NULL,
     content VARCHAR(1000) NOT NULL,

--- a/server/index.js
+++ b/server/index.js
@@ -13,14 +13,14 @@ schemaInit();
 
 // Import routes
 import factsRoutes from "./routes/factsRoutes.js";
-// const jokesRoutes = require("./routes/jokesRoutes");
-// const recipiesRoutes = require("./routes/recipiesRoutes");
+import jokesRoutes from "./routes/jokesRoutes.js";
+import recipesRoutes from "./routes/recipesRoutes.js";
 // const reportsRoutes = require("./routes/reportsRoutes");
 
 // Use routes
 app.use("/api/facts", factsRoutes);
-// app.use("/api/jokes", jokesRoutes);
-// app.use("/api/recipies", recipiesRoutes);
+app.use("/api/jokes", jokesRoutes);
+app.use("/api/recipes", recipesRoutes);
 // app.use("/api/reports", reportsRoutes);
 
 // Start server

--- a/server/routes/factsRoutes.js
+++ b/server/routes/factsRoutes.js
@@ -28,15 +28,15 @@ router.get("/today", async (req, res) => {
     }
 });
 
+// Create new fact
 router.post("/create", async (req, res) => {
     try {
         const fact = req.body.fact;
         if(!fact) {
-            res.status(400).json({error: "Request does not contain fact data."});
+            res.status(400).json({error: `Request does not contain fact data.`});
             return;
         }
     
-        // Verify request data
         const requiredKeys = new Set(['date', 'content', 'source', 'category']);
         for(const key in fact) {
             if(!key in requiredKeys) {
@@ -50,6 +50,6 @@ router.post("/create", async (req, res) => {
     } catch (error) {
         res.status(500).json({ error: `Failed to create fact: ${error}` });
     }
-})
+});
 
 export default router;

--- a/server/routes/factsRoutes.js
+++ b/server/routes/factsRoutes.js
@@ -3,7 +3,7 @@ const router = Router();
 
 import { getCurrentFact, getFacts } from "../db/queries/facts.js";
   
-// Get all facts route (example)
+// Get all facts
 router.get("/", async (req, res) => {
 try {
     const clubs = await getFacts();
@@ -13,7 +13,7 @@ try {
 }
 });
 
-// Get the curent date's fact
+// Get the current date's fact
 router.get("/today", async (req, res) => {
     try {
         const clubs = await getCurrentFact();

--- a/server/routes/factsRoutes.js
+++ b/server/routes/factsRoutes.js
@@ -31,15 +31,15 @@ router.get("/today", async (req, res) => {
 // Create new fact
 router.post("/create", async (req, res) => {
     try {
-        const fact = req.body.fact;
-        if(!fact) {
+        if(!req.body || !('fact' in req.body)) {
             res.status(400).json({error: `Request does not contain fact data.`});
             return;
         }
-    
-        const requiredKeys = new Set(['date', 'content', 'source', 'category']);
-        for(const key in fact) {
-            if(!key in requiredKeys) {
+        
+        const fact = req.body.fact;
+        const requiredKeys = ['date', 'content', 'source', 'category'];
+        for(const key of requiredKeys) {
+            if(!(key in fact)) {
                 res.status(400).json({ error: `Missing required key: ${key}` });
                 return;
             }

--- a/server/routes/factsRoutes.js
+++ b/server/routes/factsRoutes.js
@@ -1,7 +1,7 @@
 import { Router } from "express";
 const router = Router();
 
-import { getCurrentFact, getFacts } from "../db/queries/facts.js";
+import { createFact, getCurrentFact, getFacts } from "../db/queries/facts.js";
   
 // Get all facts
 router.get("/", async (req, res) => {
@@ -27,5 +27,29 @@ router.get("/today", async (req, res) => {
         res.status(500).json({ error: "Failed to get facts" });
     }
 });
+
+router.post("/create", async (req, res) => {
+    try {
+        const fact = req.body.fact;
+        if(!fact) {
+            res.status(400).json({error: "Request does not contain fact data."});
+            return;
+        }
+    
+        // Verify request data
+        const requiredKeys = new Set(['date', 'content', 'source', 'category']);
+        for(const key in fact) {
+            if(!key in requiredKeys) {
+                res.status(400).json({ error: `Missing required key: ${key}` });
+                return;
+            }
+        }
+    
+        const id = await createFact(fact);
+        res.json({factId: id});
+    } catch (error) {
+        res.status(500).json({ error: `Failed to create fact: ${error}` });
+    }
+})
 
 export default router;

--- a/server/routes/jokesRoutes.js
+++ b/server/routes/jokesRoutes.js
@@ -1,2 +1,31 @@
 import { Router } from "express";
 const router = Router();
+
+import { getCurrentJokes, getJokes } from "../db/queries/jokes.js";
+  
+// Get all jokes
+router.get("/", async (req, res) => {
+try {
+    const clubs = await getJokes();
+    res.json(clubs);
+} catch (error) {
+    res.status(500).json({ error: "Failed to get jokes" });
+}
+});
+
+// Get the current date's jokes
+router.get("/today", async (req, res) => {
+    try {
+        const clubs = await getCurrentJokes();
+        if(!clubs) {
+            res.status(404).json({error: "No jokes of the day found."});
+            return;
+        }
+
+        res.json(clubs);
+    } catch (error) {
+        res.status(500).json({ error: "Failed to get jokes" });
+    }
+});
+
+export default router;

--- a/server/routes/jokesRoutes.js
+++ b/server/routes/jokesRoutes.js
@@ -1,7 +1,7 @@
 import { Router } from "express";
 const router = Router();
 
-import { getCurrentJokes, getJokes } from "../db/queries/jokes.js";
+import { getCurrentJokes, getJokes, createJoke } from "../db/queries/jokes.js";
   
 // Get all jokes
 router.get("/", async (req, res) => {
@@ -37,9 +37,9 @@ router.post("/create", async (req, res) => {
             return;
         }
     
-        const requiredKeys = new Set(['date', 'content', 'source']);
-        for(const key in joke) {
-            if(!key in requiredKeys) {
+        const requiredKeys = new Set(['date', 'content']);
+        for(const key of requiredKeys) {
+            if(!(key in joke)) {
                 res.status(400).json({ error: `Missing required key: ${key}` });
                 return;
             }

--- a/server/routes/jokesRoutes.js
+++ b/server/routes/jokesRoutes.js
@@ -28,4 +28,28 @@ router.get("/today", async (req, res) => {
     }
 });
 
+// Create new joke
+router.post("/create", async (req, res) => {
+    try {
+        const joke = req.body.joke;
+        if(!joke) {
+            res.status(400).json({error: `Request does not contain joke data.`});
+            return;
+        }
+    
+        const requiredKeys = new Set(['date', 'content', 'source']);
+        for(const key in joke) {
+            if(!key in requiredKeys) {
+                res.status(400).json({ error: `Missing required key: ${key}` });
+                return;
+            }
+        }
+    
+        const id = await createJoke(joke);
+        res.json({jokeId: id});
+    } catch (error) {
+        res.status(500).json({ error: `Failed to create joke: ${error}` });
+    }
+});
+
 export default router;

--- a/server/routes/recipesRoutes.js
+++ b/server/routes/recipesRoutes.js
@@ -1,7 +1,7 @@
 import { Router } from "express";
 const router = Router();
 
-import { getCurrentRecipe, getRecipes } from "../db/queries/recipes.js";
+import { getCurrentRecipe, getRecipes, createRecipe } from "../db/queries/recipes.js";
   
 // Get all recipes
 router.get("/", async (req, res) => {
@@ -25,6 +25,30 @@ router.get("/today", async (req, res) => {
         res.json(clubs);
     } catch (error) {
         res.status(500).json({ error: "Failed to get recipes" });
+    }
+});
+
+// Create new recipe
+router.post("/create", async (req, res) => {
+    try {
+        const recipe = req.body.recipe;
+        if(!recipe) {
+            res.status(400).json({error: `Request does not contain recipe data.`});
+            return;
+        }
+    
+        const requiredKeys = new Set(['date', 'content', 'category']);
+        for(const key in recipe) {
+            if(!key in requiredKeys) {
+                res.status(400).json({ error: `Missing required key: ${key}` });
+                return;
+            }
+        }
+    
+        const id = await createRecipe(recipe);
+        res.json({recipeId: id});
+    } catch (error) {
+        res.status(500).json({ error: `Failed to create recipe: ${error}` });
     }
 });
 

--- a/server/routes/recipesRoutes.js
+++ b/server/routes/recipesRoutes.js
@@ -1,0 +1,31 @@
+import { Router } from "express";
+const router = Router();
+
+import { getCurrentRecipe, getRecipes } from "../db/queries/recipes.js";
+  
+// Get all recipes
+router.get("/", async (req, res) => {
+try {
+    const clubs = await getRecipes();
+    res.json(clubs);
+} catch (error) {
+    res.status(500).json({ error: "Failed to get recipes" });
+}
+});
+
+// Get the current date's recipe
+router.get("/today", async (req, res) => {
+    try {
+        const clubs = await getCurrentRecipe();
+        if(!clubs) {
+            res.status(404).json({error: "No recipes of the day found."});
+            return;
+        }
+
+        res.json(clubs);
+    } catch (error) {
+        res.status(500).json({ error: "Failed to get recipes" });
+    }
+});
+
+export default router;

--- a/server/routes/recipesRoutes.js
+++ b/server/routes/recipesRoutes.js
@@ -38,8 +38,8 @@ router.post("/create", async (req, res) => {
         }
     
         const requiredKeys = new Set(['date', 'content', 'category']);
-        for(const key in recipe) {
-            if(!key in requiredKeys) {
+        for(const key of requiredKeys) {
+            if(!(key in recipe)) {
                 res.status(400).json({ error: `Missing required key: ${key}` });
                 return;
             }

--- a/server/routes/recipiesRoutes.js
+++ b/server/routes/recipiesRoutes.js
@@ -1,2 +1,0 @@
-import { Router } from "express";
-const router = Router();

--- a/server/test/facts.test.js
+++ b/server/test/facts.test.js
@@ -3,7 +3,6 @@ import express, {json} from "express";
 import factsRouter from "../routes/factsRoutes.js";
 import { getCurrentFact, getFacts, createFact } from "../db/queries/facts.js";
 
-// Mock the getCurrentFact and getFacts functions
 jest.mock("../db/queries/facts.js");
 
 const app = express();

--- a/server/test/facts.test.js
+++ b/server/test/facts.test.js
@@ -1,15 +1,16 @@
 import request from "supertest";
-import express from "express";
+import express, {json} from "express";
 import factsRouter from "../routes/factsRoutes.js";
-import { getCurrentFact, getFacts } from "../db/queries/facts.js";
+import { getCurrentFact, getFacts, createFact } from "../db/queries/facts.js";
 
 // Mock the getCurrentFact and getFacts functions
 jest.mock("../db/queries/facts.js");
 
 const app = express();
+app.use(json());
 app.use("/facts", factsRouter);
 
-describe("Facts Routes", () => {
+describe("GET Endpoints", () => {
   
   afterEach(() => {
     jest.clearAllMocks();
@@ -69,4 +70,70 @@ describe("Facts Routes", () => {
     expect(response.body).toEqual({ error: "Failed to get facts" });
   });
 
+});
+
+describe("POST endpoints", () => {
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Test for missing fact data in the request body
+  test("should return 400 if fact data is missing", async () => {
+      const response = await request(app)
+          .post("/facts/create")
+          .send({});
+      
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("Request does not contain fact data.");
+  });
+
+  // Test for missing required keys in the fact object
+  test("should return 400 if fact is missing required keys", async () => {
+      const response = await request(app)
+          .post("/facts/create")
+          .send({ fact: { date: "2025-03-26", content: "Some content" } });
+      
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("Missing required key: source");
+  });
+
+  // Test successful fact creation
+  test("should create a fact and return the factId", async () => {
+      createFact.mockResolvedValue("12345");
+
+      const factData = {
+          date: "2025-03-26",
+          content: "Some fact content",
+          source: "Some source",
+          category: "Some category"
+      };
+
+      const response = await request(app)
+          .post("/facts/create")
+          .send({ fact: factData });
+
+      expect(response.status).toBe(200);
+      expect(response.body.factId).toBe("12345");
+      expect(createFact).toHaveBeenCalledWith(factData);
+  });
+
+  // Test for failure when createFact throws an error
+  test("should return 500 if createFact fails", async () => {
+      createFact.mockRejectedValue(new Error("Failed to create fact"));
+
+      const factData = {
+          date: "2025-03-26",
+          content: "Some fact content",
+          source: "Some source",
+          category: "Some category"
+      };
+
+      const response = await request(app)
+          .post("/facts/create")
+          .send({ fact: factData });
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBe("Failed to create fact: Error: Failed to create fact");
+  });
 });

--- a/server/test/jokes.test.js
+++ b/server/test/jokes.test.js
@@ -3,7 +3,6 @@ import express, {json} from "express";
 import jokesRouter from "../routes/jokesRoutes.js";
 import { getCurrentJokes, getJokes, createJoke } from "../db/queries/jokes.js";
 
-// Mock the getCurrentjoke and getjokes functions
 jest.mock("../db/queries/jokes.js");
 
 const app = express();
@@ -11,7 +10,7 @@ app.use(json());
 app.use("/jokes", jokesRouter);
 
 
-describe("Jokes Routes", () => {
+describe("GET Endpoints", () => {
   
   afterEach(() => {
     jest.clearAllMocks();

--- a/server/test/jokes.test.js
+++ b/server/test/jokes.test.js
@@ -1,0 +1,136 @@
+import request from "supertest";
+import express, {json} from "express";
+import jokesRouter from "../routes/jokesRoutes.js";
+import { getCurrentJokes, getJokes, createJoke } from "../db/queries/jokes.js";
+
+// Mock the getCurrentjoke and getjokes functions
+jest.mock("../db/queries/jokes.js");
+
+const app = express();
+app.use(json());
+app.use("/jokes", jokesRouter);
+
+
+describe("Jokes Routes", () => {
+  
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Success path for /jokes
+  test("GET /jokes should return all jokes", async () => {
+    const mockJokes = [{ id: 1, joke: "Joke 1" }, { id: 2, joke: "Joke 2" }];
+    getJokes.mockResolvedValue(mockJokes);
+
+    const response = await request(app).get("/jokes");
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockJokes);
+    expect(getJokes).toHaveBeenCalledTimes(1);
+  });
+
+  // Success path for /jokes/today
+  test("GET /jokes/today should return today's jokes", async () => {
+    const mockJokes = [{ id: 1, joke: "Joke of the day" }];
+    getCurrentJokes.mockResolvedValue(mockJokes);
+
+    const response = await request(app).get("/jokes/today");
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockJokes);
+    expect(getCurrentJokes).toHaveBeenCalledTimes(1);
+  });
+
+  // Alternate path for 'no joke found'
+  test("GET /jokes/today should return 404 if no jokes are found", async () => {
+    getCurrentJokes.mockResolvedValue(null);
+
+    const response = await request(app).get("/jokes/today");
+    
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: "No jokes of the day found." });
+    expect(getCurrentJokes).toHaveBeenCalledTimes(1);
+  });
+
+  // Alternate paths for server errors
+  test("GET /jokes should handle errors gracefully", async () => {
+    getJokes.mockRejectedValue(new Error("Database error"));
+
+    const response = await request(app).get("/jokes");
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: "Failed to get jokes" });
+  });
+
+  test("GET /jokes/today should handle errors gracefully", async () => {
+    getCurrentJokes.mockRejectedValue(new Error("Database error"));
+
+    const response = await request(app).get("/jokes/today");
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: "Failed to get jokes" });
+  });
+
+});
+
+describe("POST endpoints", () => {
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Test for missing joke data in the request body
+  test("should return 400 if jokes data is missing", async () => {
+      const response = await request(app)
+          .post("/jokes/create")
+          .send({});
+      
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("Request does not contain joke data.");
+  });
+
+  // Test for missing required keys in the joke object
+  test("should return 400 if joke is missing required keys", async () => {
+      const response = await request(app)
+          .post("/jokes/create")
+          .send({ joke: { date: "2025-03-26" } });
+      
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("Missing required key: content");
+  });
+
+  // Test successful joke creation
+  test("should create a joke and return the jokeId", async () => {
+      createJoke.mockResolvedValue("12345");
+
+      const jokeData = {
+          date: "2025-03-26",
+          content: "Some joke content"
+      };
+
+      const response = await request(app)
+          .post("/jokes/create")
+          .send({ joke: jokeData });
+
+      expect(response.status).toBe(200);
+      expect(response.body.jokeId).toBe("12345");
+      expect(createJoke).toHaveBeenCalledWith(jokeData);
+  });
+
+  // Test for failure when createJoke throws an error
+  test("should return 500 if createJoke fails", async () => {
+      createJoke.mockRejectedValue(new Error("Failed to create joke"));
+
+      const jokeData = {
+          date: "2025-03-26",
+          content: "Some joke content"
+      };
+
+      const response = await request(app)
+          .post("/jokes/create")
+          .send({ joke: jokeData });
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBe("Failed to create joke: Error: Failed to create joke");
+  });
+});

--- a/server/test/recipes.test.js
+++ b/server/test/recipes.test.js
@@ -1,0 +1,137 @@
+import request from "supertest";
+import express, {json} from "express";
+import recipesRouter from "../routes/recipesRoutes.js";
+import { getRecipes, getCurrentRecipe, createRecipe } from "../db/queries/recipes.js";
+
+jest.mock("../db/queries/recipes.js");
+
+const app = express();
+app.use(json());
+app.use("/recipes", recipesRouter);
+
+
+describe("GET Endpoints", () => {
+  
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Success path for /recipes
+  test("GET /recipes should return all recipes", async () => {
+    const mockRecipes = [{ id: 1, recipe: "Recipe 1" }, { id: 2, recipe: "Recipe 2" }];
+    getRecipes.mockResolvedValue(mockRecipes);
+
+    const response = await request(app).get("/recipes");
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockRecipes);
+    expect(getRecipes).toHaveBeenCalledTimes(1);
+  });
+
+  // Success path for /recipes/today
+  test("GET /recipes/today should return today's recipes", async () => {
+    const mockRecipe = { id: 1, recipe: "recipe of the day" };
+    getCurrentRecipe.mockResolvedValue(mockRecipe);
+
+    const response = await request(app).get("/recipes/today");
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockRecipe);
+    expect(getCurrentRecipe).toHaveBeenCalledTimes(1);
+  });
+
+  // Alternate path for 'no recipe found'
+  test("GET /recipes/today should return 404 if no recipes are found", async () => {
+    getCurrentRecipe.mockResolvedValue(null);
+
+    const response = await request(app).get("/recipes/today");
+    
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: "No recipes of the day found." });
+    expect(getCurrentRecipe).toHaveBeenCalledTimes(1);
+  });
+
+  // Alternate paths for server errors
+  test("GET /recipes should handle errors gracefully", async () => {
+    getRecipes.mockRejectedValue(new Error("Database error"));
+
+    const response = await request(app).get("/recipes");
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: "Failed to get recipes" });
+  });
+
+  test("GET /recipes/today should handle errors gracefully", async () => {
+    getCurrentRecipe.mockRejectedValue(new Error("Database error"));
+
+    const response = await request(app).get("/recipes/today");
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: "Failed to get recipes" });
+  });
+
+});
+
+describe("POST endpoints", () => {
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Test for missing recipe data in the request body
+  test("should return 400 if recipes data is missing", async () => {
+      const response = await request(app)
+          .post("/recipes/create")
+          .send({});
+      
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("Request does not contain recipe data.");
+  });
+
+  // Test for missing required keys in the recipe object
+  test("should return 400 if recipe is missing required keys", async () => {
+      const response = await request(app)
+          .post("/recipes/create")
+          .send({ recipe: { date: "2025-03-26" } });
+      
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("Missing required key: content");
+  });
+
+  // Test successful recipe creation
+  test("should create a recipe and return the recipeId", async () => {
+      createRecipe.mockResolvedValue("12345");
+
+      const recipeData = {
+          date: "2025-03-26",
+          content: "Some recipe content",
+          category: "default"
+      };
+
+      const response = await request(app)
+          .post("/recipes/create")
+          .send({ recipe: recipeData });
+
+      expect(response.status).toBe(200);
+      expect(response.body.recipeId).toBe("12345");
+      expect(createRecipe).toHaveBeenCalledWith(recipeData);
+  });
+
+  // Test for failure when createrecipe throws an error
+  test("should return 500 if createrecipe fails", async () => {
+      createRecipe.mockRejectedValue(new Error("Failed to create recipe"));
+
+      const recipeData = {
+          date: "2025-03-26",
+          content: "Some recipe content",
+          category: "default"
+      };
+
+      const response = await request(app)
+          .post("/recipes/create")
+          .send({ recipe: recipeData });
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBe("Failed to create recipe: Error: Failed to create recipe");
+  });
+});


### PR DESCRIPTION
Defined following endpoints:
- `/facts/createFact` (POST)
- `/jokes/` (GET)
- `/jokes/today` (GET)
- `/jokes/createJoke` (POST)
- `/recipes/` (GET)
- `/recipes/today` (GET)
- `/recipes/createRecipe` (POST)

Things to note:
- Currently hardcoded lists of required keys for each `create` endpoint, could be stored in domain object and handled better in the future for error messages
- Updated DB schema to include `default` as a `recipe_category` option.
- Fixed typos.

- [x] Unit Tests
- [ ] Code Review
- [ ] Merged